### PR TITLE
[DOCS] Link extensions documentation from packagist and other tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "description": "Additional password validators for usage in TYPO3 password policies",
   "homepage": "https://github.com/derhansen/add_pwd_policy",
   "support": {
+		"docs": "https://github.com/derhansen/add_pwd_policy/blob/main/README.md",
     "issues": "https://github.com/derhansen/add_pwd_policy/issues"
   },
   "authors": [


### PR DESCRIPTION
By providing the support->docs section in the composer.json your extensions documentation is automatically linked from packagist and any place it is mentioned in the TYPO3 documentation.